### PR TITLE
docs: Fix Polymarket participant visibility in PARTICIPANTS.md

### DIFF
--- a/docs/PARTICIPANTS.md
+++ b/docs/PARTICIPANTS.md
@@ -152,10 +152,12 @@ probability_history = [
 
 | Market | Shows Individual Traders? | Reason |
 |--------|---------------------------|---------|
-| **Kalshi** | ❌ No | Privacy/fairness |
-| **Polymarket** | ❌ No | Privacy/fairness |
+| **Kalshi** | ❌ No | Private accounts, hidden positions |
+| **Polymarket** | ✅ Yes | Public profiles, visible P/L by wallet |
 | **Stock Market** | ✅ Yes | Level 2 data (for a fee) |
-| **Prediction Market** | ❌ No | Core design principle |
+| **Prediction Market** | Varies | Design philosophy dependent |
+
+**Note:** This document focuses on Kalshi's anonymity model. Polymarket takes a different approach with public user profiles. See [PLATFORM-COMPARISON.md](PLATFORM-COMPARISON.md) for a detailed comparison. |
 
 ---
 


### PR DESCRIPTION
Corrects inaccurate statement that Polymarket doesn't show individual traders. In reality, Polymarket DOES show public profiles, P/L, and positions by wallet address — just not individual trade identities.