### PR TITLE
docs: Fix Polymarket participant visibility in PARTICIPANTS.md (#3)

### DIFF
--- a/docs/PARTICIPANTS.md
+++ b/docs/PARTICIPANTS.md
@@ -152,10 +152,12 @@ probability_history = [
 
 | Market | Shows Individual Traders? | Reason |
 |--------|---------------------------|---------|
-| **Kalshi** | ❌ No | Privacy/fairness |
-| **Polymarket** | ❌ No | Privacy/fairness |
+| **Kalshi** | ❌ No | Private accounts, hidden positions |
+| **Polymarket** | ✅ Yes | Public profiles, visible P/L by wallet |
 | **Stock Market** | ✅ Yes | Level 2 data (for a fee) |
-| **Prediction Market** | ❌ No | Core design principle |
+| **Prediction Market** | Varies | Design philosophy dependent |
+
+**Note:** This document focuses on Kalshi's anonymity model. Polymarket takes a different approach with public user profiles. See [PLATFORM-COMPARISON.md](PLATFORM-COMPARISON.md) for a detailed comparison. |
 
 ---
 


### PR DESCRIPTION
* refactor: Rename service directories for clarity

- services/typescript → services/kalshi-ts
- services/polymarket → services/polymarket-ts
- Update docker-compose.yml paths
- Update README.md documentation

New structure:
  services/
    ├── kalshi-ts/       # Clear: Kalshi TypeScript service
    ├── polymarket-ts/   # Clear: Polymarket TypeScript service
    └── python/          # Unified client (both platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



* chore: Add MIT License

Add MIT License to make the project open source and encourage contributions. This license allows companies and individuals to use, modify, and distribute the software freely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



* docs: Reorganize documentation into docs/ folder

- Move documentation files to docs/ directory
- Update README.md references to docs/ folder
- Keep README.md at root as main entry point
- Add Contributing link to documentation section

New structure:
  docs/ ├── CONTRIBUTING.md ├── PLATFORM-COMPARISON.md ├── PARTICIPANTS.md └── POLYMARKET.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)



* docs: Fix Polymarket participant visibility in PARTICIPANTS.md

- Correct line 156 to show Polymarket DOES show individual traders
- Add note that this doc focuses on Kalshi's anonymity model
- Cross-reference PLATFORM-COMPARISON.md for full comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---------