### PR TITLE
fix: Add missing getOrder function to Kalshi client

### DIFF
--- a/services/kalshi-ts/src/kalshi.client.ts
+++ b/services/kalshi-ts/src/kalshi.client.ts
@@ -191,6 +191,16 @@ export async function listOrders(params: {
   }
 }
 
+export async function getOrder(orderId: string) {
+  try {
+    const response = await ordersApi.getOrder(orderId);
+    return { order: response.data.order };
+  } catch (error: any) {
+    console.error(`Failed to fetch order ${orderId}:`, error.response?.data || error.message);
+    throw error;
+  }
+}
+
 export async function amendOrder(params: {
   orderId: string;
   count?: number;


### PR DESCRIPTION
## Summary

- Fixes bug where `GET /api/orders/:id` endpoint called undefined `getOrder()` function
- Adds `getOrder(orderId: string)` to `kalshi.client.ts`
- Maps to official Kalshi API: `GET /trade-api/v2/portfolio/orders/{order_id}`

## Root Cause

The `server.ts` imported and used `getOrder` but the function was never implemented in `kalshi.client.ts`.

## Changes

- Added `getOrder` function in `services/kalshi-ts/src/kalshi.client.ts:194-202`
- Follows same pattern as other order functions (`createOrder`, `cancelOrder`, `amendOrder`)

## Testing

The endpoint can now be called without error:
```bash
curl http://localhost:3000/api/orders/{order_id}
```

## Related

- Found during Issue #5 review
- Official API: https://docs.kalshi.com/api-reference/orders/get-order

🤖 Generated with [Claude Code](https://claude.com/claude-code)